### PR TITLE
Infer castling rights when converting board images

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -31,6 +31,22 @@ def generate_templates(square_size: int) -> Dict[str, np.ndarray]:
     return templates
 
 
+def infer_castling_rights(board: chess.Board) -> None:
+    """Infer and set castling rights based on king and rook positions."""
+    rights = []
+    if board.piece_at(chess.E1) == chess.Piece.from_symbol("K"):
+        if board.piece_at(chess.H1) == chess.Piece.from_symbol("R"):
+            rights.append("K")
+        if board.piece_at(chess.A1) == chess.Piece.from_symbol("R"):
+            rights.append("Q")
+    if board.piece_at(chess.E8) == chess.Piece.from_symbol("k"):
+        if board.piece_at(chess.H8) == chess.Piece.from_symbol("r"):
+            rights.append("k")
+        if board.piece_at(chess.A8) == chess.Piece.from_symbol("r"):
+            rights.append("q")
+    board.set_castling_fen("".join(rights) or "-")
+
+
 def board_from_image(path: str) -> chess.Board:
     img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
     if img is None:
@@ -58,6 +74,7 @@ def board_from_image(path: str) -> chess.Board:
             if best_symbol and best_score > 0.7:
                 square = chess.square(file, 7 - rank)
                 board.set_piece_at(square, chess.Piece.from_symbol(best_symbol))
+    infer_castling_rights(board)
     return board
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import chess
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from convert import infer_castling_rights
+
+
+def test_infer_castling_rights_start_position():
+    """Castling rights should be inferred for starting position pieces."""
+    start = chess.Board()
+    board = chess.Board(None)
+    for square, piece in start.piece_map().items():
+        board.set_piece_at(square, piece)
+    infer_castling_rights(board)
+    assert board.fen() == chess.STARTING_FEN


### PR DESCRIPTION
## Summary
- infer castling availability from king and rook positions
- call the inference in `board_from_image` so `board.fen()` outputs a full FEN
- add unit test ensuring castling rights are detected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925a258d48833189a7b53b47b6cf35