### PR TITLE
Ensure template labels are decoded to strings

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -77,6 +77,7 @@ def load_templates() -> Tuple["np.ndarray", "np.ndarray"]:
         samples = samples.astype(np.float32, copy=False)
         samples = samples.reshape(samples.shape[0], -1)
         samples = _normalize_rows(samples)
+        labels = np.asarray(labels).astype(str)
         return samples, labels
 
     try:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -37,3 +37,18 @@ def test_load_templates_uses_embedded_defaults(monkeypatch, tmp_path):
     samples, labels = convert.load_templates()
     assert samples.shape[0] == labels.shape[0] > 0
     assert samples.ndim == 2
+
+
+def test_load_templates_decodes_byte_labels(monkeypatch, tmp_path):
+    """Byte-encoded labels should be decoded to strings for classification."""
+    path = tmp_path / "custom_templates.npz"
+    samples = np.zeros((2, convert.CLASSIFIER_IMAGE_SIZE, convert.CLASSIFIER_IMAGE_SIZE), dtype=np.uint8)
+    labels = np.array([b"p", b"."], dtype="S1")
+    np.savez(path, samples=samples, labels=labels)
+
+    monkeypatch.setattr(convert, "TEMPLATE_FILE", str(path))
+    monkeypatch.setattr(convert, "_TEMPLATES", None)
+
+    _, loaded_labels = convert.load_templates()
+    assert loaded_labels.dtype.kind == "U"
+    assert isinstance(loaded_labels[0], str)


### PR DESCRIPTION
## Summary
- normalize template labels to unicode strings when loading custom template archives
- add regression test covering byte-encoded labels

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8725f499c833184723def0683842c