### PR TITLE
Adjust empty-square heuristic to reduce piece drops

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -492,7 +492,9 @@ def board_from_image(path: str) -> chess.Board:
             best_symbol, best_error = prediction.candidates[0]
             empty_error = prediction.error_for('.')
 
-            if best_symbol != '.' and (empty_error == float('inf') or empty_error > best_error * 1.05):
+            if best_symbol != '.' and (
+                empty_error == float("inf") or best_error < empty_error
+            ):
                 board.set_piece_at(square_index, chess.Piece.from_symbol(best_symbol))
 
     ensure_legal_board(board, predictions)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -93,3 +93,14 @@ def test_ensure_legal_board_removes_backrank_pawns():
     assert board.piece_at(chess.A8) is None
     assert board.king(chess.WHITE) == chess.E1
     assert board.king(chess.BLACK) == chess.E8
+
+
+def test_board_from_image_detects_complete_position():
+    """The converter should not drop real pieces when they edge out emptiness."""
+
+    board = convert.board_from_image(str(ROOT / "board.png"))
+
+    assert (
+        board.fen()
+        == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
+    )


### PR DESCRIPTION
## Summary
- accept classified pieces whenever they beat the empty-square template instead of requiring a 5% margin
- keep the infinite empty-score fallback when no empty template is available
- add a regression test that converts the sample board image and checks the full FEN output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2d3138348331abce9f0b3a552514